### PR TITLE
 unuse obsolete files

### DIFF
--- a/basepkg.sh
+++ b/basepkg.sh
@@ -32,43 +32,46 @@ extract_base_binaries() {
 		if [ ! -d ./work/${i} ]; then
 			mkdir -p ./work/${i}
 		fi
-		tar zxvf ${sets}/${i}.tgz -C ./work/$i
+		tar zxvf ${sets}/${i}.tgz -C ./work/${i}
 	done
 }
 
 # "dir" option using following functions.
 split_category_from_lists() {
-	for i in $category
+	for i in ${category}
 	do
-		if [ ! -d ./$i ]; then
-			mkdir ./$i
+		if [ ! -d ./${i} ]; then
+			mkdir ./${i}
 		fi
-		if [ -f ./$i/FILES ]; then
-			rm -f ./$i/FILES
+		if [ -f ./${i}/FILES ]; then
+			rm -f ./${i}/FILES
 		fi
-		for j in `ls $lists`
+		for j in `ls ${lists}`
 		do
-			grep -E "$i-[a-z]+-[a-z]+" $lists/$j/mi | \
-			sed -e 's/^\.\///' -e '/^#/d' >> ./$i/FILES
+			grep -E "${i}-[a-z]+-[a-z]+" ${lists}/${j}/mi | \
+			grep -v "obsolete" | \
+			sed -e 's/^\.\///' -e '/^#/d' >> ./${i}/FILES
 	
-			test -f $lists/$j/md.$machine && grep -E "$i-[a-z]+-[a-z]+" \
-			$lists/$j/md.$machine | sed -e 's/^\.\///' -e '/^#/d' \
-			>> ./$i/FILES
+			if [ -f ${lists}/${j}/md.${machine} ]; then
+				grep -E "${i}-[a-z]+-[a-z]+" ${lists}/${j}/md.${machine} | \
+				grep -v "obsolete" | \
+				sed -e 's/^\.\///' -e '/^#/d' >> ./${i}/FILES
+			fi
 		done
 	done
 }
 
 make_directories_of_package() {
-	for i in $category
+	for i in ${category}
 	do
-		awk '{print $2}' ./$i/FILES | sort | uniq | \
-		xargs -n 1 -I % mkdir ./$i/%
+		awk '{print $2}' ./${i}/FILES | sort | uniq | \
+		xargs -n 1 -I % mkdir ./${i}/%
 	done
 }
 
 # "list" option using following function.
 make_contents_list() {
-	for i in $category
+	for i in ${category}
 	do
 		awk ' 
 		# $1 - file name
@@ -85,27 +88,27 @@ make_contents_list() {
 		END {
 			for(pkg in lists)
 				print pkg, lists[pkg]
-		}' $i/FILES > ./$i/CATEGORIZED
+		}' ${i}/FILES > ./${i}/CATEGORIZED
 	done
-	for i in $category
+	for i in ${category}
 	do
-		for j in `ls ./$i | grep '^[a-z]'`
+		for j in `ls ./${i} | grep '^[a-z]'`
 		do
-			grep "$j" ./$i/CATEGORIZED | tr ' ' '\n' | \
+			grep "${j}" ./${i}/CATEGORIZED | tr ' ' '\n' | \
 			awk 'NR != 1{print $0}' | sort | \
-			grep -v -E "x$i-[a-z]+-[a-z]+" > ./$i/$j/$j.FILES
+			grep -v -E "x${i}-[a-z]+-[a-z]+" > ./${i}/${j}/${j}.FILES
 		done
 	done
 }
 
 # "pkg" option using following functions.
 make_BUILD_INFO(){
-	echo "OPSYS=$opsys" > ./$1/+BUILD_INFO
-	echo "OS_VERSION=$osversion" >> ./$1/+BUILD_INFO
+	echo "OPSYS=${opsys}" > ./$1/+BUILD_INFO
+	echo "OS_VERSION=${osversion}" >> ./$1/+BUILD_INFO
 	echo "OBJECT_FMT=ELF" >> ./$1/+BUILD_INFO
-	echo "MACHINE_ARCH=$machine_arch" >> ./$1/+BUILD_INFO
+	echo "MACHINE_ARCH=${machine_arch}" >> ./$1/+BUILD_INFO
 	echo "MACHINE_GNU_ARCH=${MACHINE_GNU_ARCH}" >> ./$1/+BUILD_INFO
-	echo "PKGTOOLS_VERSION=$pkgtoolversion" >> ./$1/+BUILD_INFO
+	echo "PKGTOOLS_VERSION=${pkgtoolversion}" >> ./$1/+BUILD_INFO
 }
 
 make_COMMENT(){
@@ -120,23 +123,24 @@ make_CONTENTS() {
 	fi
 	setname=`echo $1 | awk 'BEGIN{FS="/"} {print $1}' | sed 's/\./-/g'`
 	pkgname=`echo $1 | awk 'BEGIN{FS="/"} {print $2}' | sed 's/\./-/g'`
-	echo "@name $pkgname-`sh ${SRC}/sys/conf/osrelease.sh`" > ./$1/+CONTENTS
-	echo "@comment Packaged at ${utcdate} UTC by ${user}@${host}" >> ./$1/+CONTENTS
+	echo "@name ${pkgname}-`sh ${SRC}/sys/conf/osrelease.sh`" > ./$1/+CONTENTS
+	echo "@comment Packaged at ${utcdate} UTC by ${user}@${host}" \
+	>> ./$1/+CONTENTS
 	echo "@comment Packaged using ${prog} ${rcsid}" >> ./$1/+CONTENTS
 	echo "@cwd /" >> ./$1/+CONTENTS
 	# XXX: This package may be empty package
-	cat ./$1/$pkgname.FILES | while read i
+	cat ./$1/${pkgname}.FILES | while read i
 	do
-		filetype=`file ./work/$setname/$i | awk '{print $2}'`
-		if [ $filetype = directory ]; then
-			filename=`echo $i | sed 's%\/%\\\/%g'`
-			awk '$1 ~ /^\.\/'"${filename}"'$/{print $0}' ./work/$setname/etc/mtree/set.$setname | \
+		filetype=`file ./work/$setname/${i} | awk '{print $2}'`
+		if [ ${filetype} = directory ]; then
+			filename=`echo ${i} | sed 's%\/%\\\/%g'`
+			awk '$1 ~ /^\.\/'"${filename}"'$/{print $0}' ./work/${setname}/etc/mtree/set.${setname} | \
 			sed 's%^\.\/%%' | \
 			awk '{print "@exec install -d -o root -g wheel -m "substr($5, 6) " "$1}' >> ./$1/tmp.list
-		elif [ $filetype = cannot ]; then
+		elif [ ${filetype} = cannot ]; then
 			continue
 		else
-			echo $i >> ./$1/tmp.list
+			echo ${i} >> ./$1/tmp.list
 		fi
 	done
 	if [ ! -f ./$1/tmp.list ]; then
@@ -158,17 +162,18 @@ make_PKG() {
 	setname=`echo $1 | awk 'BEGIN{FS="/"} {print $1}' | sed 's/\./-/g'`
 	pkgname=`echo $1 | awk 'BEGIN{FS="/"} {print $2}' | sed 's/\./-/g'`
 	pkg_create -l -U -B $1/+BUILD_INFO -c $1/+COMMENT \
-	-d $1/+DESC -f $1/+CONTENTS -I / -p ${PWD}/work/$setname $pkgname
+	-d $1/+DESC -f $1/+CONTENTS -I / -p ${PWD}/work/${setname} ${pkgname}
 	if [ $? != 0 ]; then
 		return $?
 	fi
 	if [ ! -d ${PACKAGES} ]; then
 	  mkdir ${PACKAGES}
 	fi
-	if [ ! -d ${PACKAGES}/$setname ]; then
-	  mkdir -p ${PACKAGES}/$setname
+	if [ ! -d ${PACKAGES}/${setname} ]; then
+	  mkdir -p ${PACKAGES}/${setname}
 	fi
-	mv ./$pkgname.tgz ${PACKAGES}/$setname/$pkgname-`sh ${SRC}/sys/conf/osrelease.sh`.tgz
+	mv ./${pkgname}.tgz \
+	${PACKAGES}/${setname}/${pkgname}-`sh ${SRC}/sys/conf/osrelease.sh`.tgz
 }
 
 make_packages() {
@@ -176,12 +181,12 @@ make_packages() {
 	do
 		for j in `ls ./${i} | grep -E '^[a-z]+'`
 		do
-			echo "Package $i/$j Creating..."
-			make_BUILD_INFO $i/$j
-			make_COMMENT $i/$j
-			make_CONTENTS $i/$j
-			make_DESC $i/$j
-			make_PKG $i/$j
+			echo "Package ${i}/${j} Creating..."
+			make_BUILD_INFO ${i}/${j}
+			make_COMMENT ${i}/${j}
+			make_CONTENTS ${i}/${j}
+			make_DESC ${i}/${j}
+			make_PKG ${i}/${j}
 		done
 	done
 }
@@ -198,19 +203,18 @@ clean_categories() {
 	done
 }
 
+# self-explanatorily :-)
 usage() {
 	echo "usage: ./basepkg.sh <option>"
 	echo " Options:"
-	echo "   extract   extract base binary"
-	echo "   dir       create packages directory"
-	echo "   list      create packages list"
-	echo "   pkg       create packages"
+	echo "   extract  extract base binary"
+	echo "   dir      create packages directory"
+	echo "   list     create packages list"
+	echo "   pkg      create packages"
+	echo "   all      running dir,list,pkg options"
+	echo "   clean    remove all packages and created directories"
 	exit 1
 }
-
-if [ $# != 1 ]; then
-	usage
-fi
 
 case $1 in
 	extract)


### PR DESCRIPTION
When running "./basepkg.sh dir", file with "obsolete" tag included in package categorized file named "FILE". I cleared this problem.